### PR TITLE
Ipv6 network iterator

### DIFF
--- a/src/ipv6_network.rs
+++ b/src/ipv6_network.rs
@@ -664,6 +664,21 @@ impl IntoIterator for Ipv6Network {
     type Item = Ipv6Addr;
     type IntoIter = iterator::Ipv6RangeIterator;
 
+    /// Returns iterator over all IP addresses in range including network and last addresses.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::net::Ipv6Addr;
+    /// use ip_network::Ipv6Network;
+    ///
+    /// let ip = Ipv6Addr::new(0x2001, 0, 0, 0, 0, 0, 0x0002, 0);
+    /// let mut iter = Ipv6Network::new(ip, 120)?.into_iter();
+    /// assert_eq!(iter.next().unwrap(), Ipv6Addr::new(0x2001, 0, 0, 0, 0, 0, 0x0002, 0));
+    /// assert_eq!(iter.next().unwrap(), Ipv6Addr::new(0x2001, 0, 0, 0, 0, 0, 0x0002, 1));
+    /// assert_eq!(iter.last().unwrap(), Ipv6Addr::new(0x2001, 0, 0, 0, 0, 0, 0x0002, 0x00ff));
+    /// # Ok::<(), ip_network::IpNetworkError>(())
+    /// ```
     fn into_iter(self) -> Self::IntoIter {
         Self::IntoIter::new(self.network_address, self.last_address())
     }
@@ -750,6 +765,21 @@ mod tests {
         )
         .unwrap();
         assert_eq!(ip_network.into_iter().len(), 16 * 16 * 16 * 16);
+    }
+
+    #[test]
+    fn iterator_for() {
+        let ip_network = Ipv6Network::new(
+            Ipv6Addr::new(0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0, 0),
+            112,
+        )
+        .unwrap();
+
+        let mut i = 0;
+        for _ in ip_network {
+            i += 1;
+        }
+        assert_eq!(i, 16 * 16 * 16 * 16);
     }
 
     #[test]

--- a/src/ipv6_network.rs
+++ b/src/ipv6_network.rs
@@ -743,6 +743,16 @@ mod tests {
     }
 
     #[test]
+    fn iterator() {
+        let ip_network = Ipv6Network::new(
+            Ipv6Addr::new(0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0, 0),
+            112,
+        )
+        .unwrap();
+        assert_eq!(ip_network.into_iter().len(), 16 * 16 * 16 * 16);
+    }
+
+    #[test]
     fn subnets() {
         let mut subnets = return_test_ipv6_network().subnets();
         assert_eq!(subnets.len(), 2);

--- a/src/ipv6_network.rs
+++ b/src/ipv6_network.rs
@@ -660,6 +660,15 @@ impl Hash for Ipv6Network {
     }
 }
 
+impl IntoIterator for Ipv6Network {
+    type Item = Ipv6Addr;
+    type IntoIter = iterator::Ipv6RangeIterator;
+
+    fn into_iter(self) -> Self::IntoIter {
+        Self::IntoIter::new(self.network_address, self.last_address())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::net::Ipv6Addr;

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -201,7 +201,7 @@ impl Ipv6RangeIterator {
     ///
     /// let mut iterator = Ipv6RangeIterator::new(
     ///     Ipv6Addr::new(0x2001, 0, 0, 0, 0, 0, 0x0002, 0),
-    ///     Ipv6Addr::new(0x2001, 0, 0, 0, 0, 0, 0x0002, 0x00FF)
+    ///     Ipv6Addr::new(0x2001, 0, 0, 0, 0, 0, 0x0002, 0x00ff)
     /// );
     /// assert_eq!(
     ///     iterator.next().unwrap(),
@@ -213,7 +213,7 @@ impl Ipv6RangeIterator {
     /// );
     /// assert_eq!(
     ///     iterator.last().unwrap(),
-    ///     Ipv6Addr::new(0x2001, 0, 0, 0, 0, 0, 0x0002, 0x00FF)
+    ///     Ipv6Addr::new(0x2001, 0, 0, 0, 0, 0, 0x0002, 0x00ff)
     /// );
     /// ```
     pub fn new(from: Ipv6Addr, to: Ipv6Addr) -> Self {
@@ -425,7 +425,7 @@ mod tests {
     fn ipv6_range_iterator() {
         let mut iterator = Ipv6RangeIterator::new(
             Ipv6Addr::new(0x2001, 0, 0, 0, 0, 0, 0x0002, 0),
-            Ipv6Addr::new(0x2001, 0, 0, 0, 0, 0, 0x0002, 0x00FF),
+            Ipv6Addr::new(0x2001, 0, 0, 0, 0, 0, 0x0002, 0x00ff),
         );
         assert_eq!(
             iterator.next().unwrap(),
@@ -437,7 +437,7 @@ mod tests {
         );
         assert_eq!(
             iterator.last().unwrap(),
-            Ipv6Addr::new(0x2001, 0, 0, 0, 0, 0, 0x0002, 0x00FF)
+            Ipv6Addr::new(0x2001, 0, 0, 0, 0, 0, 0x0002, 0x00ff)
         );
     }
 
@@ -445,7 +445,7 @@ mod tests {
     fn ipv64_range_iterator_length() {
         let mut iterator = Ipv6RangeIterator::new(
             Ipv6Addr::new(0x2001, 0, 0, 0, 0, 0, 0x0002, 0),
-            Ipv6Addr::new(0x2001, 0, 0, 0, 0, 0, 0x0002, 0x00FF),
+            Ipv6Addr::new(0x2001, 0, 0, 0, 0, 0, 0x0002, 0x00ff),
         );
         assert_eq!(iterator.len(), 256);
         iterator.next().unwrap();
@@ -457,16 +457,16 @@ mod tests {
     fn ipv6_range_iterator_same_values() {
         let mut iterator = Ipv6RangeIterator::new(
             Ipv6Addr::new(
-                0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+                0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff,
             ),
             Ipv6Addr::new(
-                0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+                0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff,
             ),
         );
         assert_eq!(iterator.len(), 1);
         assert_eq!(
             iterator.next().unwrap(),
-            Ipv6Addr::new(0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF)
+            Ipv6Addr::new(0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff)
         );
         assert!(iterator.next().is_none());
         assert_eq!(iterator.len(), 0);

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -179,6 +179,7 @@ impl Iterator for Ipv4NetworkIterator {
 
 impl ExactSizeIterator for Ipv4NetworkIterator {}
 
+/// IPv6 range iterator.
 pub struct Ipv6RangeIterator {
     current: u128,
     to: u128,
@@ -186,6 +187,35 @@ pub struct Ipv6RangeIterator {
 }
 
 impl Ipv6RangeIterator {
+    /// Constructs new `Ipv6RangeIterator` for given range, both `from` and `to` address are inclusive.
+    ///
+    /// # Panics
+    ///
+    /// When `to` address is bigger or same than `from` address.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::net::Ipv6Addr;
+    /// use ip_network::iterator::Ipv6RangeIterator;
+    ///
+    /// let mut iterator = Ipv6RangeIterator::new(
+    ///     Ipv6Addr::new(0x2001, 0, 0, 0, 0, 0, 0x0002, 0),
+    ///     Ipv6Addr::new(0x2001, 0, 0, 0, 0, 0, 0x0002, 0x00FF)
+    /// );
+    /// assert_eq!(
+    ///     iterator.next().unwrap(),
+    ///     Ipv6Addr::new(0x2001, 0, 0, 0, 0, 0, 0x0002, 0)
+    /// );
+    /// assert_eq!(
+    ///     iterator.next().unwrap(),
+    ///     Ipv6Addr::new(0x2001, 0, 0, 0, 0, 0, 0x0002, 0x0001)
+    /// );
+    /// assert_eq!(
+    ///     iterator.last().unwrap(),
+    ///     Ipv6Addr::new(0x2001, 0, 0, 0, 0, 0, 0x0002, 0x00FF)
+    /// );
+    /// ```
     pub fn new(from: Ipv6Addr, to: Ipv6Addr) -> Self {
         let current = u128::from(from);
         let to = u128::from(to);
@@ -394,20 +424,20 @@ mod tests {
     #[test]
     fn ipv6_range_iterator() {
         let mut iterator = Ipv6RangeIterator::new(
-            Ipv6Addr::new(0x2001, 0, 0, 0, 0, 0, 2, 0),
-            Ipv6Addr::new(0x2001, 0, 0, 0, 0, 0, 2, 0x00FF),
+            Ipv6Addr::new(0x2001, 0, 0, 0, 0, 0, 0x0002, 0),
+            Ipv6Addr::new(0x2001, 0, 0, 0, 0, 0, 0x0002, 0x00FF),
         );
         assert_eq!(
             iterator.next().unwrap(),
-            Ipv6Addr::new(0x2001, 0, 0, 0, 0, 0, 2, 0)
+            Ipv6Addr::new(0x2001, 0, 0, 0, 0, 0, 0x0002, 0)
         );
         assert_eq!(
             iterator.next().unwrap(),
-            Ipv6Addr::new(0x2001, 0, 0, 0, 0, 0, 2, 0x0001)
+            Ipv6Addr::new(0x2001, 0, 0, 0, 0, 0, 0x0002, 0x0001)
         );
         assert_eq!(
             iterator.last().unwrap(),
-            Ipv6Addr::new(0x2001, 0, 0, 0, 0, 0, 2, 0x00FF)
+            Ipv6Addr::new(0x2001, 0, 0, 0, 0, 0, 0x0002, 0x00FF)
         );
     }
 

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -179,6 +179,53 @@ impl Iterator for Ipv4NetworkIterator {
 
 impl ExactSizeIterator for Ipv4NetworkIterator {}
 
+pub struct Ipv6RangeIterator {
+    current: u128,
+    to: u128,
+    is_done: bool,
+}
+
+impl Ipv6RangeIterator {
+    pub fn new(from: Ipv6Addr, to: Ipv6Addr) -> Self {
+        let current = u128::from(from);
+        let to = u128::from(to);
+        assert!(to >= current);
+        Self {
+            current,
+            to,
+            is_done: false,
+        }
+    }
+}
+
+impl Iterator for Ipv6RangeIterator {
+    type Item = Ipv6Addr;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.current <= self.to && !self.is_done {
+            let output = self.current;
+
+            match self.current.checked_add(1) {
+                Some(x) => self.current = x,
+                None => self.is_done = true,
+            };
+
+            Some(Self::Item::from(output))
+        } else {
+            None
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        if self.is_done {
+            return (0, Some(0));
+        }
+
+        let remaining = (self.to - self.current + 1) as usize;
+        (remaining, Some(remaining))
+    }
+}
+
 /// Iterates over new created IPv6 network from given network.
 pub struct Ipv6NetworkIterator {
     current: u128,


### PR DESCRIPTION
Implements `Ipv6RangeIterator`, and uses this to implement `IntoIterator` for `Ipv6Network`.